### PR TITLE
2.0.0 coaks changes

### DIFF
--- a/Source/Core/Core/Config/GraphicsSettings.cpp
+++ b/Source/Core/Core/Config/GraphicsSettings.cpp
@@ -29,6 +29,7 @@ const Info<int> GFX_SAFE_TEXTURE_CACHE_COLOR_SAMPLES{
 const Info<bool> GFX_SHOW_FPS{{System::GFX, "Settings", "ShowFPS"}, false};
 const Info<bool> GFX_SHOW_BATTER_FIELDER{{System::GFX, "Settings", "ShowBatterFielder"}, true};
 const Info<bool> GFX_TRAINING_MODE{{System::GFX, "Settings", "TrainingModeOverlay"}, false};
+const Info<bool> GFX_DRAFT_TIMER{{System::GFX, "Settings", "DraftTimer"}, true};
 const Info<bool> GFX_SHOW_NETPLAY_PING{{System::GFX, "Settings", "ShowNetPlayPing"}, true};
 const Info<bool> GFX_SHOW_NETPLAY_MESSAGES{{System::GFX, "Settings", "ShowNetPlayMessages"}, false};
 const Info<bool> GFX_LOG_RENDER_TIME_TO_FILE{{System::GFX, "Settings", "LogRenderTimeToFile"},

--- a/Source/Core/Core/Config/GraphicsSettings.h
+++ b/Source/Core/Core/Config/GraphicsSettings.h
@@ -31,6 +31,7 @@ extern const Info<int> GFX_SAFE_TEXTURE_CACHE_COLOR_SAMPLES;
 extern const Info<bool> GFX_SHOW_FPS;
 extern const Info<bool> GFX_SHOW_BATTER_FIELDER;
 extern const Info<bool> GFX_TRAINING_MODE;
+extern const Info<bool> GFX_DRAFT_TIMER;
 extern const Info<bool> GFX_SHOW_NETPLAY_PING;
 extern const Info<bool> GFX_SHOW_NETPLAY_MESSAGES;
 extern const Info<bool> GFX_LOG_RENDER_TIME_TO_FILE;

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -201,7 +201,7 @@ void FrameUpdateOnCPUThread()
   SetNetplayerUserInfo();
   SetDisplayStats();
 
-  CodeWriter.RunCodeInject(Memory::Read_U8(aNetplayEventCode) == 1, isRankedMode(), isNight(), GameMode);
+  CodeWriter.RunCodeInject(Memory::Read_U8(aNetplayEventCode) == 1, isRankedMode(), isNight(), GameMode, isDisableReplays());
 
   AutoGolfMode();
   TrainingMode();
@@ -572,6 +572,13 @@ bool isNight()
   if (!NetPlay::IsNetPlayRunning())
     return false;
   return NetPlay::NetPlayClient::isNight();
+}
+
+bool isDisableReplays()
+{
+  if (!NetPlay::IsNetPlayRunning())
+    return false;
+  return NetPlay::NetPlayClient::isDisableReplays();
 }
 
 void SetAvgPing()

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -197,7 +197,7 @@ void FrameUpdateOnCPUThread()
   SetNetplayerUserInfo();
   SetDisplayStats();
 
-  CodeWriter.RunCodeInject(Memory::Read_U8(aNetplayEventCode) == 1, isRankedMode(), isNight());
+  CodeWriter.RunCodeInject(Memory::Read_U8(aNetplayEventCode) == 1, isRankedMode(), isNight(), GameMode);
 
   AutoGolfMode();
   TrainingMode();
@@ -1640,6 +1640,25 @@ void SetGameID(u32 gameID)
     s_stat_tracker = std::make_unique<StatTracker>();
     s_stat_tracker->init();
     s_stat_tracker->setGameID(gameID);
+  }
+}
+
+void SetGameMode(std::string mode)
+{
+  if (mode == "Superstars OFF")
+  {
+    GameMode = 1;
+    //GameMode = GameMode::StarsOff;
+  }
+  else if (mode == "Superstars ON")
+  {
+    GameMode = 2;
+    //GameMode = GameMode::StarsOn;
+  }
+  else
+  {
+    GameMode = 0;
+    //GameMode = GameMode::Custom;
   }
 }
 

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -209,6 +209,12 @@ void FrameUpdateOnCPUThread()
   SetAvgPing();
   SendGameID();
   RunDraftTimer();
+
+  if (!bHasWrittenStadium && Movie::GetCurrentFrame() == 240 && NetPlay::IsNetPlayRunning()) // wait 4 seconds
+  {
+    DefaultStadiumGecko();
+    bHasWrittenStadium = true;
+  }
 }
 
 void OnFrameEnd()
@@ -712,6 +718,10 @@ bool Init(std::unique_ptr<BootParameters> boot, const WindowSystemInfo& wsi)
   // Start the emu thread
   s_is_booting.Set();
   s_emu_thread = std::thread(EmuThread, std::move(boot), prepared_wsi);
+
+  // do this too lol ~LittleCoaks
+  bHasWrittenStadium = false;
+
   return true;
 }
 
@@ -1699,6 +1709,25 @@ void SetGameMode(std::string mode)
   {
     GameMode = 0;
     //GameMode = GameMode::Custom;
+  }
+}
+
+void DefaultStadiumGecko(u8 stadium, u8 stadium_id)
+{
+  if (IsRunning())
+  {
+    if (stadium == 0xff)
+      stadium = m_stadium;
+    if (stadium_id == 0xff)
+      stadium_id = m_stadium_id;
+    
+    Memory::Write_U32(0x38000000 + stadium, 0x80650934);
+    Memory::Write_U8(stadium_id, 0x80E016A7);
+  }
+  else
+  {
+    m_stadium = stadium;
+    m_stadium_id = stadium_id;
   }
 }
 

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -161,16 +161,18 @@ double GetActualEmulationSpeed()
 
 void FrameUpdateOnCPUThread()
 {
-  if (NetPlay::IsNetPlayRunning()) {
-    //NetPlay::NetPlayClient::SendTimeBase();
+  if (NetPlay::IsNetPlayRunning())
+  {
+    // NetPlay::NetPlayClient::SendTimeBase();
     u64 frame = Movie::GetCurrentFrame();
     if (frame % 60)
     {
       u8 checksumId = (frame / 60) & 0xF;
       NetPlay::NetPlayClient::SendChecksum(checksumId, frame);
     }
-    if (s_stat_tracker){
-      //Figure out if client is hosting via netplay settings. Could use local player as well
+    if (s_stat_tracker)
+    {
+      // Figure out if client is hosting via netplay settings. Could use local player as well
       bool is_hosting = NetPlay::GetNetSettings().m_IsHosting;
       std::string opponent_name = "";
       /*
@@ -183,8 +185,10 @@ void FrameUpdateOnCPUThread()
       s_stat_tracker->setNetplaySession(true, is_hosting, opponent_name);
     }
   }
-  else{
-    if (s_stat_tracker){
+  else
+  {
+    if (s_stat_tracker)
+    {
       s_stat_tracker->setNetplaySession(false);
     }
   }

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -187,6 +187,7 @@ void DisplayBatterFielder();
 void SetAvgPing();
 void SetNetplayerUserInfo();
 void SendGameID();
+void RunDraftTimer();
 
 bool hasSentGameID = false;
 static int avgPing = 0;
@@ -219,6 +220,8 @@ union{
 
 bool previousContactMade = false;
 
+int draftTimer = 0;
+
 static const u32 aOpponentPort = 0x802EBF92;
 static const u32 aFielderPort = 0x802EBF94;
 static const u32 aBatterPort = 0x802EBF95;
@@ -244,6 +247,7 @@ static const u32 aWallBallPort = 0x80890AD9; // port of character pitching in wa
 static const u32 aMinigameID = 0x808980DE;  // 3 == Barrel Batter; 2 == Wall Ball; 1 == Bom-omb Derby; 4 == Chain Chomp Sprint; 5 == Piranha Panic; 6 == Star Dash; 7 == Grand Prix
 static const u32 aNetplayEventCode = 0x802EBF96;
 static const u32 aWhoPaused = 0x8039D7D3; // 2 == fielder, 1 == batter
-static const u32 aMatchStarted = 0x8036F3A8; // bool for if a game is in session
+static const u32 aMatchStarted = 0x80317376;  // bool for if a game is in session
+static const u32 aSceneId = 0x800E877F;
 
 }  // namespace Core

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -180,6 +180,7 @@ float vectorMagnitude(float x, float y, float z);
 float RoundZ(float num);
 bool isRankedMode();
 bool isNight();
+bool isDisableReplays();
 
 void AutoGolfMode();
 void TrainingMode();

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -194,12 +194,23 @@ static int nPing = 0;
 static int nLagSpikes = 0;
 static int previousPing = 0;
 
+//enum class GameMode
+//{
+//  StarsOff,
+//  StarsOn,
+//  Custom,
+//};
+
+// auto GameMode = GameMode::Custom;
+u32 GameMode = 0;
+
 //void setRankedStatus(bool inNewStatus);
 void setRecordStatus(bool inNewStatus);
 void setSubmitStatus(bool inNewStatus);
 void setRankedStatus(bool inNewStatus);
 void SetDisplayStats();
 void SetGameID(u32 gameID);
+void SetGameMode(std::string mode);
 
 union{
   u32 num;

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -190,6 +190,7 @@ void SendGameID();
 void RunDraftTimer();
 
 bool hasSentGameID = false;
+bool bHasWrittenStadium = false;
 static int avgPing = 0;
 static int nPing = 0;
 static int nLagSpikes = 0;
@@ -212,6 +213,7 @@ void setRankedStatus(bool inNewStatus);
 void SetDisplayStats();
 void SetGameID(u32 gameID);
 void SetGameMode(std::string mode);
+void DefaultStadiumGecko(u8 stadium = 0xff, u8 stadium_id = 0xff);
 
 union{
   u32 num;
@@ -221,6 +223,8 @@ union{
 bool previousContactMade = false;
 
 int draftTimer = 0;
+u8 m_stadium = 0;
+u8 m_stadium_id = 0;
 
 static const u32 aOpponentPort = 0x802EBF92;
 static const u32 aFielderPort = 0x802EBF94;

--- a/Source/Core/Core/DefaultGeckoCodes.cpp
+++ b/Source/Core/Core/DefaultGeckoCodes.cpp
@@ -71,6 +71,12 @@ void DefaultGeckoCodes::InjectNetplayEventCode()
 
   Memory::Write_U8(0x1, aUnlockEverything_5);
 
+  if (!(GameMode == 1 && IsRanked))  // if stars off ranked, don't unlock superstars
+  {
+    for (int i = 0; i <= 0x35; i++)
+      Memory::Write_U8(0x1, aUnlockEverything_6 + i);
+  }
+
   for (int i = 0; i <= 0x3; i++)
     Memory::Write_U8(0x1, aUnlockEverything_7 + i);
 
@@ -93,12 +99,6 @@ void DefaultGeckoCodes::AddRankedCodes()
   WriteAsm(sPitchClock);
  
   Memory::Write_U32(0x386001bb, aBatSound);
-
-  if (GameMode != 1)  // if stars off ranked, don't unlock superstars
-  {
-    for (int i = 0; i <= 0x35; i++)
-      Memory::Write_U8(0x1, aUnlockEverything_6 + i);
-  }
 
   if (Memory::Read_U32(aBanBatterPausing) == 0xA0040006)
     Memory::Write_U32(0x38000000, aBanBatterPausing);

--- a/Source/Core/Core/DefaultGeckoCodes.cpp
+++ b/Source/Core/Core/DefaultGeckoCodes.cpp
@@ -15,6 +15,11 @@ void DefaultGeckoCodes::RunCodeInject(bool bNetplayEventCode, bool bIsRanked, bo
 
   Memory::Write_U8(0x1, aControllerRumble);  // enable rumble
 
+  // this is a very bad and last-minute "fix" to the pitcher stamina bug. i can't find the true source of the bug so i'm
+  // manually fixing it with this line here. will remove soon once bug is truly squashed
+  if (Memory::Read_U8(0x8069BBDD) == 0xC5)
+    Memory::Write_U8(05, 0x8069BBDD);
+
   // handle asm writes for required code
   for (DefaultGeckoCode geckocode : sRequiredCodes)
     WriteAsm(geckocode);

--- a/Source/Core/Core/DefaultGeckoCodes.cpp
+++ b/Source/Core/Core/DefaultGeckoCodes.cpp
@@ -3,12 +3,13 @@
 #include "Config/NetplaySettings.h"
 #include <VideoCommon/VideoConfig.h>
 
-void DefaultGeckoCodes::RunCodeInject(bool bNetplayEventCode, bool bIsRanked, bool bIsNight, u32 uGameMode)
+void DefaultGeckoCodes::RunCodeInject(bool bNetplayEventCode, bool bIsRanked, bool bIsNight, u32 uGameMode, bool bDisableReplays)
 {
   NetplayEventCode = bNetplayEventCode;
   IsRanked = bIsRanked;
   IsNight = bIsNight;
   GameMode = uGameMode; //1 == stars off, 2 == stars on, 0 == anything else
+  DisableReplays = bDisableReplays;
 
   aWriteAddr = 0x802ED200;  // starting asm write addr
 
@@ -32,6 +33,12 @@ void DefaultGeckoCodes::RunCodeInject(bool bNetplayEventCode, bool bIsRanked, bo
   {
     if (IsNight)
       WriteAsm(sNightStadium);
+
+    if (DisableReplays)
+    {
+      if (Memory::Read_U32(aDisableReplays) == 0x38000001)
+        Memory::Write_U32(0x38000000, aDisableReplays);
+    }
 
     if (Config::Get(Config::NETPLAY_DISABLE_MUSIC))
     {

--- a/Source/Core/Core/DefaultGeckoCodes.cpp
+++ b/Source/Core/Core/DefaultGeckoCodes.cpp
@@ -8,7 +8,7 @@ void DefaultGeckoCodes::RunCodeInject(bool bNetplayEventCode, bool bIsRanked, bo
   NetplayEventCode = bNetplayEventCode;
   IsRanked = bIsRanked;
   IsNight = bIsNight;
-  GameMode = uGameMode;
+  GameMode = uGameMode; //1 == stars off, 2 == stars on, 0 == anything else
 
   aWriteAddr = 0x802ED200;  // starting asm write addr
 
@@ -71,12 +71,6 @@ void DefaultGeckoCodes::InjectNetplayEventCode()
 
   Memory::Write_U8(0x1, aUnlockEverything_5);
 
-  if (!(IsRanked && GameMode == 1))  // if stars off ranked, don't unlock superstars
-  {
-    for (int i = 0; i <= 0x35; i++)
-      Memory::Write_U8(0x1, aUnlockEverything_6 + i);
-  }
-
   for (int i = 0; i <= 0x3; i++)
     Memory::Write_U8(0x1, aUnlockEverything_7 + i);
 
@@ -99,6 +93,17 @@ void DefaultGeckoCodes::AddRankedCodes()
   WriteAsm(sPitchClock);
  
   Memory::Write_U32(0x386001bb, aBatSound);
+
+  if (GameMode != 1)  // if stars off ranked, don't unlock superstars
+  {
+    for (int i = 0; i <= 0x35; i++)
+      Memory::Write_U8(0x1, aUnlockEverything_6 + i);
+  }
+
+  if (Memory::Read_U32(aBanBatterPausing) == 0xA0040006)
+    Memory::Write_U32(0x38000000, aBanBatterPausing);
+
+  WriteAsm(sHazardless);
 }
 
 

--- a/Source/Core/Core/DefaultGeckoCodes.h
+++ b/Source/Core/Core/DefaultGeckoCodes.h
@@ -10,9 +10,14 @@
 
 class DefaultGeckoCodes {
   public:
-    void RunCodeInject(bool bNetplayEventCode, bool bIsRanked, bool bIsNight);
+    void RunCodeInject(bool bNetplayEventCode, bool bIsRanked, bool bIsNight, u32 uGameMode);
 
   private:
+    bool NetplayEventCode;
+    bool IsRanked;
+    bool IsNight;
+    u32 GameMode;
+
 
     // Default Rumble On [LittleCoaks]
     static const u32 aControllerRumble = 0x80366177;

--- a/Source/Core/Core/DefaultGeckoCodes.h
+++ b/Source/Core/Core/DefaultGeckoCodes.h
@@ -146,8 +146,9 @@ class DefaultGeckoCodes {
     // Anti Quick Pitch [PeacockSlayer, LittleCoaks]
     const DefaultGeckoCode sAntiQuickPitch = {
         0x806B406C, 0xa01e0006,
-        {0x3DC08089, 0x61CE80DE, 0x89CE0000, 0x2C0E0000, 0x4082001C, 0x38000000,
-        0x3DC08089, 0x61CE0AE0, 0xA1CE0000, 0x2C0E0060, 0x40810008, 0xA01E0006}
+        {0x3DC08089, 0x61CE80DE, 0x89CE0000, 0x2C0E0000, 0x40820030, 0x38000000, 0x3DC08089,
+         0x61CE0AE0, 0xA1CE0000, 0x2C0E0030, 0x4081001C, 0x3DC08089, 0x61CE099D, 0x89CE0000,
+         0x2C0E0001, 0x41820008, 0xA01E0006}
     };
 
     // Default Competitive Rules [LittleCoaks]

--- a/Source/Core/Core/DefaultGeckoCodes.h
+++ b/Source/Core/Core/DefaultGeckoCodes.h
@@ -10,13 +10,14 @@
 
 class DefaultGeckoCodes {
   public:
-    void RunCodeInject(bool bNetplayEventCode, bool bIsRanked, bool bIsNight, u32 uGameMode);
+    void RunCodeInject(bool bNetplayEventCode, bool bIsRanked, bool bIsNight, u32 uGameMode, bool bDisableReplays);
 
   private:
     bool NetplayEventCode;
     bool IsRanked;
     bool IsNight;
     u32 GameMode;
+    bool DisableReplays;
 
 
     // Default Rumble On [LittleCoaks]
@@ -61,6 +62,9 @@ class DefaultGeckoCodes {
 
     // Ban Batter Pausing [LittleCoaks]
     static const u32 aBanBatterPausing = 0x806eed5c; // write to 0x38000000 if equal to 0xA0040006
+
+    // Disable Replays [LittleCoaks]
+    static const u32 aDisableReplays = 0x806bb214; // write  to 0x38000000 if equal to 0x38000001
 
     void InjectNetplayEventCode();
     void AddRankedCodes();

--- a/Source/Core/Core/DefaultGeckoCodes.h
+++ b/Source/Core/Core/DefaultGeckoCodes.h
@@ -59,6 +59,8 @@ class DefaultGeckoCodes {
     static const u32 aNeverCull_3 = 0x806ab8b4;  // write to 0x38000001
     static const u32 aNeverCull_4 = 0x806f7b7c;  // write to 0x38000003 if equal to 0x881a0093
 
+    // Ban Batter Pausing [LittleCoaks]
+    static const u32 aBanBatterPausing = 0x806eed5c; // write to 0x38000000 if equal to 0xA0040006
 
     void InjectNetplayEventCode();
     void AddRankedCodes();
@@ -140,7 +142,7 @@ class DefaultGeckoCodes {
     const DefaultGeckoCode sAntiQuickPitch = {
         0x806B406C, 0xa01e0006,
         {0x3DC08089, 0x61CE80DE, 0x89CE0000, 0x2C0E0000, 0x4082001C, 0x38000000,
-        0x3DC08089, 0x61CE099D, 0x89CE0000, 0x2C0E0001, 0x41820008, 0xA01E0006}
+        0x3DC08089, 0x61CE0AE0, 0xA1CE0000, 0x2C0E0060, 0x40810008, 0xA01E0006}
     };
 
     // Default Competitive Rules [LittleCoaks]
@@ -232,10 +234,28 @@ class DefaultGeckoCodes {
          0x60A5BFB8, 0x90850000, 0xB8610008, 0x80010104, 0x38210100, 0x7C0803A6,
          0x3C80800F}};  // 0x802EBFB8 == checksum addr
 
+
+    // Hold Z for Easy Batting [Roeming]
     const DefaultGeckoCode sEasyBattingZ = {
         0x806A82B0, 0x28000000,
         {0x3CA08089, 0x38852990, 0x80040000, 0x1C000004, 0x38852A78, 0x7C840214,
         0x80040000, 0x1C000010,0x3885392C, 0x7C840214, 0xA0040000, 0x70000010, 0x28000000}
+    };
+
+
+    // Hazardless Stadiums [LittleCoaks, PeacockSlayer]
+    const DefaultGeckoCode sHazardless = {
+        0x80699508, 0x88a40009,
+        {0x88A40009, 0x9421FFB0, 0xBDC10008, 0x3E608035, 0x6273323B, 0x3AA00000, 0x7E93A8AE,
+         0x2C140001, 0x418200D8, 0x3AB50001, 0x2C150012, 0x4082FFEC, 0x2C050000, 0x418200C4,
+         0x2C050006, 0x408000BC, 0x2C050001, 0x41820028, 0x2C050002, 0x4182003C, 0x2C050003,
+         0x41820050, 0x2C050004, 0x4182005C, 0x2C050005, 0x4182007C, 0x48000090, 0x3E608070,
+         0x627356C8, 0x3E803860, 0x92930000, 0x3E803800, 0x92931638, 0x48000074, 0x3E608070,
+         0x6273FC30, 0x3E806000, 0x92930000, 0x3E803800, 0x9293376C, 0x48000058, 0x3E608069,
+         0x62739E54, 0x3E803800, 0x92930000, 0x48000044, 0x3E60807C, 0x6273D098, 0x3A800000,
+         0x3AA00000, 0x9A930011, 0x3AB50001, 0x3A730014, 0x2C150010, 0x4180FFF0, 0x4800001C,
+         0x3E608072, 0x6273F950, 0x3E806000, 0x92930000, 0x92934A54, 0x92934A60, 0xB9C10008,
+         0x38210050}
     };
 
     void WriteAsm(DefaultGeckoCode CodeBlock);
@@ -247,5 +267,5 @@ class DefaultGeckoCodes {
         sRememberWhoQuit_1, sRememberWhoQuit_2, sStoreRandBattingInts, sChecksum};
 
     std::vector<DefaultGeckoCode> sNetplayCodes =
-    {sAntiQuickPitch, sDefaultCompetitiveRules, sManualSelect,sRemoveDingus};
+    {sAntiQuickPitch, sDefaultCompetitiveRules, sManualSelect, sRemoveDingus};
 };

--- a/Source/Core/Core/DefaultGeckoCodes.h
+++ b/Source/Core/Core/DefaultGeckoCodes.h
@@ -111,15 +111,16 @@ class DefaultGeckoCodes {
     };
 
     // Store Port Info->0x802EBF94 (fielding port) and 0x802EBF95 (batting port) [LittleCoaks]
-    const DefaultGeckoCode sClearPortInfo_1 = {
-        0x80042CD0, 0,
-        {0x3CA0802E, 0x60A5BF91, 0x3C608089, 0x60632ACA, 0x88630000, 0x2C030001, 0x4182000C,
-        0x38600001, 0x48000008, 0x38600005, 0x98650000, 0x3C60800E, 0x6063874D, 0x88630000,
-        0x38630001, 0x98650001, 0x386001B8}
+    const DefaultGeckoCode sStorePortInfo_1 = {
+        0x80042CD8, 0,
+        {0x9421FFB0, 0xBDC10008, 0x3DE0802E, 0x61EFBF91, 0x3E008089, 0x62102ACA,
+        0x8A100000, 0x2C100001, 0x4182000C, 0x3A000001, 0x48000008, 0x3A000005,
+        0x9A0F0000, 0x3E00800E, 0x6210874D, 0x8A100000, 0x3A100001, 0x9A0F0001,
+        0xB9C10008, 0x38210050, 0x38A0007F}
     };
 
     // Store Port Info [LittleCoaks]
-    const DefaultGeckoCode sClearPortInfo_2 = {
+    const DefaultGeckoCode sStorePortInfo_2 = {
         0x806706B8, 0x3c608089,
         {0x3FE08089, 0x63FF3928, 0x7C04F800, 0x3FE0802E, 0x63FFBF91, 0x41820018, 0x887F0000,
         0x987F0004, 0x887F0001, 0x987F0003, 0x48000014, 0x887F0001, 0x987F0004, 0x887F0000,
@@ -263,7 +264,7 @@ class DefaultGeckoCodes {
 
     std::vector<DefaultGeckoCode> sRequiredCodes =
     {sGenerateGameID, sClearGameID_1, sClearGameID_2, sClearGameID_3,
-    sClearPortInfo, sClearHitResult, sClearPortInfo_1, sClearPortInfo_2,
+    sClearPortInfo, sClearHitResult, sStorePortInfo_1, sStorePortInfo_2,
         sRememberWhoQuit_1, sRememberWhoQuit_2, sStoreRandBattingInts, sChecksum};
 
     std::vector<DefaultGeckoCode> sNetplayCodes =

--- a/Source/Core/Core/MSB_StatTracker.h
+++ b/Source/Core/Core/MSB_StatTracker.h
@@ -1071,7 +1071,10 @@ public:
 
             //Remove current event, wasn't finished
             auto it = m_game_info.events.find(m_game_info.event_num);
-            m_game_info.events.erase(it);
+            if (&it != NULL)
+            {
+              m_game_info.events.erase(it);
+            }
 
             //Game has ended. Write file but do not submit
             std::string jsonPath = getStatJsonPath("crash.decode.");

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -505,6 +505,10 @@ void NetPlayClient::OnData(sf::Packet& packet)
     OnStadiumMsg(packet);
     break;
 
+  case MessageID::DisableReplays:
+    OnDisableReplaysMsg(packet);
+    break;
+
   default:
     PanicAlertFmtT("Unknown message received with id : {0}", static_cast<u8>(mid));
     break;
@@ -1572,6 +1576,14 @@ void NetPlayClient::OnNightMsg(sf::Packet& packet)
   m_night_stadium = is_night;
 }
 
+void NetPlayClient::OnDisableReplaysMsg(sf::Packet& packet)
+{
+  bool disable;
+  packet >> disable;
+  m_dialog->OnDisableReplaysResult(disable);
+  m_disable_replays = disable;
+}
+
 void NetPlayClient::OnChecksumMsg(sf::Packet& packet)
 {
   u32 inChecksum;
@@ -1624,6 +1636,11 @@ bool NetPlayClient::isRanked()
 bool NetPlayClient::isNight()
 {
   return netplay_client->m_night_stadium;
+}
+
+bool NetPlayClient::isDisableReplays()
+{
+  return netplay_client->m_disable_replays;
 }
 
 void NetPlayClient::DisplayBatterFielder(u8 BatterPortInt, u8 FielderPortInt)
@@ -1843,6 +1860,15 @@ void NetPlayClient::SendNightStadium(bool is_night)
   sf::Packet packet;
   packet << MessageID::NightStadium;
   packet << is_night;
+
+  SendAsync(std::move(packet));
+}
+
+void NetPlayClient::SendDisableReplays(bool disable)
+{
+  sf::Packet packet;
+  packet << MessageID::DisableReplays;
+  packet << disable;
 
   SendAsync(std::move(packet));
 }

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -501,6 +501,10 @@ void NetPlayClient::OnData(sf::Packet& packet)
     OnGameIDMsg(packet);
     break;
 
+  case MessageID::Stadium:
+    OnStadiumMsg(packet);
+    break;
+
   default:
     PanicAlertFmtT("Unknown message received with id : {0}", static_cast<u8>(mid));
     break;
@@ -1589,6 +1593,13 @@ void NetPlayClient::OnGameIDMsg(sf::Packet& packet)
   Core::SetGameID(gameID);
 }
 
+void NetPlayClient::OnStadiumMsg(sf::Packet& packet)
+{
+  int stadium;
+  packet >> stadium;
+  m_dialog->OnRandomStadiumResult(stadium);
+}
+
 void NetPlayClient::Send(const sf::Packet& packet, const u8 channel_id)
 {
   ENetPacket* epac =
@@ -1869,6 +1880,15 @@ void NetPlayClient::SendCoinFlip(int randNum)
   sf::Packet packet;
   packet << MessageID::CoinFlip;
   packet << randNum;
+
+  SendAsync(std::move(packet));
+}
+
+void NetPlayClient::SendStadium(int stadium)
+{
+  sf::Packet packet;
+  packet << MessageID::Stadium;
+  packet << stadium;
 
   SendAsync(std::move(packet));
 }

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -2618,6 +2618,7 @@ void NetPlayClient::SendGameID(u32 gameId)
 void NetPlayClient::AutoGolfMode(bool isField, int BatPort, int FieldPort)
 {
   netplay_client->AutoGolfModeLogic(isField, BatPort, FieldPort);
+  INFO_LOG_FMT(NETPLAY, "Auto Golf run"); // this needs to be here for debugger i guess
 }
 
 void NetPlayClient::AutoGolfModeLogic(bool isField, int BatPort, int FieldPort)

--- a/Source/Core/Core/NetPlayClient.cpp
+++ b/Source/Core/Core/NetPlayClient.cpp
@@ -2640,12 +2640,12 @@ void NetPlayClient::AutoGolfModeLogic(bool isField, int BatPort, int FieldPort)
   }
 
   // this little block makes it so that the auto golf logic will only complete if the client's been
-  // the golfer for more than 240 frames. this is to ensure that under laggier conditions, a golfer
+  // the golfer for more than 60 frames. this is to ensure that under laggier conditions, a golfer
   // who's game is too far behind doesn't swap the golfer status back and forth for a short while,
   // which can be extra jarring to players
   if (framesAsGolfer < 255) // don't want a memory overflow here
     framesAsGolfer += 1;
-  if (framesAsGolfer <= 240) // delay this so that swapping bugs are way less likely; 4 second lockout window (240 frames)
+  if (framesAsGolfer <= 60) // delay this so that swapping bugs are way less likely; 1 second lockout window (60 frames)
     return;
 
   // if the current golfer is also the one who should be the golfer, return

--- a/Source/Core/Core/NetPlayClient.h
+++ b/Source/Core/Core/NetPlayClient.h
@@ -73,6 +73,7 @@ public:
   virtual void OnCoinFlipResult(int coinFlip) = 0;
   virtual void OnNightResult(bool is_night) = 0;
   virtual void OnActiveGeckoCodes(std::string codeStr) = 0;
+  virtual void OnRandomStadiumResult(int stadium) = 0;
   virtual bool IsSpectating() = 0;
   virtual void SetSpectating(bool spectating) = 0;
 
@@ -139,6 +140,7 @@ public:
   void GetActiveGeckoCodes();
   void SendCoinFlip(int randNum);
   void SendNightStadium(bool is_night);
+  void SendStadium(int stadium);
   void RequestStopGame();
   void SendPowerButtonEvent();
   void RequestGolfControl(PlayerId pid);
@@ -340,6 +342,7 @@ private:
   void OnNightMsg(sf::Packet& packet);
   void OnChecksumMsg(sf::Packet& packet);
   void OnGameIDMsg(sf::Packet& packet);
+  void OnStadiumMsg(sf::Packet& packet);
 
   int framesAsGolfer = 0;
 

--- a/Source/Core/Core/NetPlayClient.h
+++ b/Source/Core/Core/NetPlayClient.h
@@ -72,6 +72,7 @@ public:
   virtual void RankedStartingMsg(bool is_ranked) = 0;
   virtual void OnCoinFlipResult(int coinFlip) = 0;
   virtual void OnNightResult(bool is_night) = 0;
+  virtual void OnDisableReplaysResult(bool disable) = 0;
   virtual void OnActiveGeckoCodes(std::string codeStr) = 0;
   virtual void OnRandomStadiumResult(int stadium) = 0;
   virtual bool IsSpectating() = 0;
@@ -141,6 +142,7 @@ public:
   void SendCoinFlip(int randNum);
   void SendNightStadium(bool is_night);
   void SendStadium(int stadium);
+  void SendDisableReplays(bool disable);
   void RequestStopGame();
   void SendPowerButtonEvent();
   void RequestGolfControl(PlayerId pid);
@@ -178,12 +180,14 @@ public:
   static void DisplayBatterFielder(u8 BatterPortInt, u8 FielderPortInt);
   static bool isRanked();
   static bool isNight();
+  static bool isDisableReplays();
   static u32 sGetPlayersMaxPing();
   static std::string sGetPortPlayer(int PortInt);
   static std::map<int, LocalPlayers::LocalPlayers::Player> getNetplayerUserInfo();
   static void SendGameID(u32 gameId);
   bool m_ranked_client = false;
   bool m_night_stadium = false;
+  bool m_disable_replays = false;
   
   const PadMappingArray& GetPadMapping() const;
   const GBAConfigArray& GetGBAConfig() const;
@@ -343,6 +347,7 @@ private:
   void OnChecksumMsg(sf::Packet& packet);
   void OnGameIDMsg(sf::Packet& packet);
   void OnStadiumMsg(sf::Packet& packet);
+  void OnDisableReplaysMsg(sf::Packet& packet);
 
   int framesAsGolfer = 0;
 

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -198,6 +198,7 @@ enum class MessageID : u8
   CoinFlip = 0xF4,
   NightStadium = 0xF5,
   GameID = 0xF6,
+  Stadium = 0xF7,
 };
 
 enum class ConnectionError : u8

--- a/Source/Core/Core/NetPlayProto.h
+++ b/Source/Core/Core/NetPlayProto.h
@@ -199,6 +199,7 @@ enum class MessageID : u8
   NightStadium = 0xF5,
   GameID = 0xF6,
   Stadium = 0xF7,
+  DisableReplays = 0xF8,
 };
 
 enum class ConnectionError : u8

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -888,6 +888,20 @@ unsigned int NetPlayServer::OnData(sf::Packet& packet, Client& player)
   }
   break;
 
+  case MessageID::Stadium:
+  {
+    int stadium;
+    packet >> stadium;
+
+    // send codes to other clients
+    sf::Packet spac;
+    spac << MessageID::Stadium;
+    spac << stadium;
+
+    SendToClients(spac);
+  }
+  break;
+
   case MessageID::PlayerData:
   {
     u8 port;

--- a/Source/Core/Core/NetPlayServer.cpp
+++ b/Source/Core/Core/NetPlayServer.cpp
@@ -874,6 +874,20 @@ unsigned int NetPlayServer::OnData(sf::Packet& packet, Client& player)
   }
   break;
 
+    case MessageID::GameID:
+  {
+    u32 id;
+    packet >> id;
+
+    // send codes to other clients
+    sf::Packet spac;
+    spac << MessageID::GameID;
+    spac << id;
+
+    SendToClients(spac);
+  }
+  break;
+
   case MessageID::PlayerData:
   {
     u8 port;

--- a/Source/Core/Core/NetPlayServer.h
+++ b/Source/Core/Core/NetPlayServer.h
@@ -69,6 +69,7 @@ public:
 
   void AdjustRankedBox(bool is_ranked);
   void AdjustNightStadium(bool is_night);
+  void AdjustReplays(bool disable);
 
   void KickPlayer(PlayerId player);
 
@@ -173,6 +174,7 @@ private:
 
   bool m_current_ranked_value = false;
   bool m_current_night_value = false;
+  bool m_current_disable_replays_value = false;
 
   std::map<PlayerId, Client> m_players;
 

--- a/Source/Core/DolphinQt/Config/AddLocalPlayers.cpp
+++ b/Source/Core/DolphinQt/Config/AddLocalPlayers.cpp
@@ -11,10 +11,12 @@
 #include <QLineEdit>
 #include <QStringList>
 #include <QTextEdit>
+#include <QPushButton>
 
 //#include "Core/LocalPlayersConfig.h"
 
 #include "DolphinQt/QtUtils/ModalMessageBox.h"
+#include <qdesktopservices.h>
 
 AddLocalPlayersEditor::AddLocalPlayersEditor(QWidget* parent) : QDialog(parent)
 {
@@ -42,9 +44,13 @@ void AddLocalPlayersEditor::CreateWidgets()
         "NOTE: the player at port 1 will\nbe used over NetPlay."));
 
   m_description = new QLabel(
-      tr("\nEnter the Username and User ID EXACTLY\nas they appear on projectrio.online and/or from your email.\n"
-         "This is necessary to send stat files to\nour database properly. If you enter an\n"
-         "invalid Username and/or User ID, your\nstats will not be saved to the database."));
+      tr("\nEnter the Username and User ID EXACTLY as they appear on projectrio.online\n"
+         "and/or from your email. This is necessary to send stat files to our database\n"
+         "properly. If you enter an invalid Username and/or User ID, your stats will\n"
+         "not be saved to the database.\n\n"
+         "If you do not have an account, you can create one below."));
+
+  m_create_account = new QPushButton(tr("Create Account"));
 
   m_button_box = new QDialogButtonBox(QDialogButtonBox::Cancel | QDialogButtonBox::Save);
 
@@ -55,8 +61,9 @@ void AddLocalPlayersEditor::CreateWidgets()
   grid_layout->addWidget(m_username_edit, 0, 1);
   grid_layout->addWidget(new QLabel(tr("User ID:")), 1, 0);
   grid_layout->addWidget(m_userid_edit, 1, 1);
-  grid_layout->addWidget(m_description, 3, 1);
-  grid_layout->addWidget(m_button_box, 4, 1);
+  grid_layout->addWidget(m_description, 2, 0, 1, -1);
+  grid_layout->addWidget(m_create_account, 3, 0);
+  grid_layout->addWidget(m_button_box, 3, 1);
 
   QFont monospace(QFontDatabase::systemFont(QFontDatabase::FixedFont).family());
 
@@ -69,8 +76,14 @@ void AddLocalPlayersEditor::ConnectWidgets()
 {
   connect(m_button_box, &QDialogButtonBox::accepted, this, &AddLocalPlayersEditor::accept);
   connect(m_button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
+  connect(m_create_account, &QPushButton::clicked, this, &AddLocalPlayersEditor::CreateAccount);
 }
 
+void AddLocalPlayersEditor::CreateAccount()
+{
+  QString url = QStringLiteral("https://projectrio-api-1.api.projectrio.app/signup/");
+  QDesktopServices::openUrl(QUrl(url));
+}
 
 bool AddLocalPlayersEditor::AcceptPlayer()
 {

--- a/Source/Core/DolphinQt/Config/AddLocalPlayers.h
+++ b/Source/Core/DolphinQt/Config/AddLocalPlayers.h
@@ -12,6 +12,7 @@ class QDialogButtonBox;
 class QLabel;
 class QLineEdit;
 class QTextEdit;
+class QPushButton;
 
 namespace AddPlayers
 {
@@ -28,6 +29,7 @@ public:
 private:
   void CreateWidgets();
   void ConnectWidgets();
+  void CreateAccount();
 
   bool AcceptPlayer();
 
@@ -36,6 +38,7 @@ private:
   QLineEdit* m_username_edit;
   QLineEdit* m_userid_edit;
   QLabel* m_description;
+  QPushButton* m_create_account;
 
   QDialogButtonBox* m_button_box;
 

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.cpp
@@ -89,6 +89,7 @@ void GeneralWidget::CreateWidgets()
   m_show_fps = new GraphicsBool(tr("Show FPS"), Config::GFX_SHOW_FPS);
   m_show_batter_fielder = new GraphicsBool(tr("Show Batting / Fielding Player"), Config::GFX_SHOW_BATTER_FIELDER);
   m_training_mode = new GraphicsBool(tr("Training Mode v1.0"), Config::GFX_TRAINING_MODE);
+  m_draft_timer = new GraphicsBool(tr("Draft Timer"), Config::GFX_DRAFT_TIMER);
   m_show_ping = new GraphicsBool(tr("Show NetPlay Ping"), Config::GFX_SHOW_NETPLAY_PING);
   m_log_render_time =
       new GraphicsBool(tr("Log Render Time to File"), Config::GFX_LOG_RENDER_TIME_TO_FILE);
@@ -111,6 +112,8 @@ void GeneralWidget::CreateWidgets()
 
   m_options_layout->addWidget(m_show_batter_fielder, 3, 0);
   m_options_layout->addWidget(m_training_mode, 3, 1);
+
+  m_options_layout->addWidget(m_draft_timer, 4, 0);
 
   // Other
   auto* shader_compilation_box = new QGroupBox(tr("Shader Compilation"));
@@ -280,6 +283,9 @@ void GeneralWidget::AddDescriptions()
       QT_TR_NOOP("Displays game informaiton on screen in real-time. Useful for "
                  "practice/testing/labbing purposes.");
 
+    static const char TR_DRAFT_TIMER[] =
+      QT_TR_NOOP("Shows how long the drafting phase of the game is taking on screen");
+
   m_backend_combo->SetTitle(tr("Backend"));
   m_backend_combo->SetDescription(tr(TR_BACKEND_DESCRIPTION));
 
@@ -299,6 +305,8 @@ void GeneralWidget::AddDescriptions()
   m_show_batter_fielder->SetDescription(tr(TR_SHOW_BATTER_FIELDER));
 
   m_training_mode->SetDescription(tr(TR_TRAINING_MODE));
+
+  m_draft_timer->SetDescription(tr(TR_DRAFT_TIMER));
 
   m_log_render_time->SetDescription(tr(TR_LOG_RENDERTIME_DESCRIPTION));
 

--- a/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.h
+++ b/Source/Core/DolphinQt/Config/Graphics/GeneralWidget.h
@@ -52,6 +52,7 @@ private:
   GraphicsBool* m_show_fps;
   GraphicsBool* m_show_batter_fielder;
   GraphicsBool* m_training_mode;
+  GraphicsBool* m_draft_timer;
   GraphicsBool* m_show_ping;
   GraphicsBool* m_log_render_time;
   GraphicsBool* m_autoadjust_window_size;

--- a/Source/Core/DolphinQt/GameList/GameList.cpp
+++ b/Source/Core/DolphinQt/GameList/GameList.cpp
@@ -588,7 +588,9 @@ void GameList::OpenWiki()
 
   QString game_id = QString::fromStdString(game->GetGameID());
   QString url =
-      QStringLiteral("https://wiki.dolphin-emu.org/dolphin-redirect.php?gameid=").append(game_id);
+      game_id.toStdString() == "GYQE01" ?
+          QStringLiteral("https://mario-superstar-baseball.fandom.com/wiki/Mario_Superstar_Baseball_Wiki")
+      : QStringLiteral("https://wiki.dolphin-emu.org/dolphin-redirect.php?gameid=").append(game_id);
   QDesktopServices::openUrl(QUrl(url));
 }
 

--- a/Source/Core/DolphinQt/MainWindow.cpp
+++ b/Source/Core/DolphinQt/MainWindow.cpp
@@ -1312,6 +1312,24 @@ void MainWindow::ShowNetPlaySetupDialog()
   m_netplay_setup_dialog->show();
   m_netplay_setup_dialog->raise();
   m_netplay_setup_dialog->activateWindow();
+
+  // Validate Rio User
+  std::string url =
+      "https://projectrio-api-1.api.projectrio.app/validate_user_from_client/?username=" +
+      LocalPlayers::m_local_player_1.GetUsername() +
+      "&rio_key=" + LocalPlayers::m_local_player_1.GetUserID();
+  const Common::HttpRequest::Response response = m_http.Get(url);
+  if (!response)
+  {
+    // TODO Error if user is not validated when full beta releases
+    // ModalMessageBox::critical(this, tr("Error"), tr("Username and Rio Key could not be
+    // validated"));
+    ModalMessageBox::warning(
+        this, tr("Warning"),
+        tr("The Username and Rio Key of the account mapped to Port 1 could not be validated.\n\n"
+           "Stat files will not be properly sent to the database if your account is invalid. You can create an account "
+           "through the \"Local Players\" tab, or through the Project Rio website."));
+  }
 }
 
 void MainWindow::ShowNetPlayBrowser()

--- a/Source/Core/DolphinQt/MainWindow.h
+++ b/Source/Core/DolphinQt/MainWindow.h
@@ -11,6 +11,8 @@
 #include <optional>
 #include <string>
 
+#include <Common/HttpRequest.h>
+
 class QStackedWidget;
 class QString;
 
@@ -246,4 +248,6 @@ private:
   WatchWidget* m_watch_widget;
   CheatsManager* m_cheats_manager;
   QByteArray m_render_widget_geometry;
+
+  Common::HttpRequest m_http{std::chrono::minutes{3}};
 };

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -518,6 +518,7 @@ void NetPlayDialog::OnActiveGeckoCodes(std::string codeStr)
 void NetPlayDialog::OnGameMode(std::string mode)
 {
   DisplayMessage(tr("Game Mode: %1").arg(QString::fromStdString(mode)), "goldenrod");
+  Core::SetGameMode(mode);
 }
 
 void NetPlayDialog::OnRankedEnabled(bool is_ranked)

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -148,6 +148,7 @@ void NetPlayDialog::CreateMainLayout()
   //    " always record stats, ignoring user configurations."));
   //m_coin_flipper = new QPushButton(tr("Coin Flip"));
   m_night_stadium = new QCheckBox(tr("Night Mario Stadium"));
+  m_disable_replays = new QCheckBox(tr("Disable Replays"));
   m_spectator_toggle = new QCheckBox(tr("Spectator"));
 
   m_data_menu = m_menu_bar->addMenu(tr("Data"));
@@ -251,6 +252,7 @@ void NetPlayDialog::CreateMainLayout()
   //options_widget->addWidget(m_ranked_box, 0, 3, Qt::AlignVCenter);
   //options_widget->addWidget(m_coin_flipper, 0, 3, Qt::AlignVCenter);
   options_widget->addWidget(m_night_stadium, 0, 3, Qt::AlignVCenter);
+  options_widget->addWidget(m_disable_replays, 0, 4, Qt::AlignVCenter);
   options_widget->addWidget(m_spectator_toggle, 0, 5, Qt::AlignVCenter | Qt::AlignRight);
 
   m_main_layout->addLayout(options_widget, 2, 0, 1, -1, Qt::AlignRight);
@@ -380,6 +382,15 @@ void NetPlayDialog::ConnectWidgets()
       server->AdjustNightStadium(is_night);
     else
       client->SendNightStadium(is_night);
+  });
+
+  connect(m_disable_replays, &QCheckBox::stateChanged, [this](bool disable) {
+    auto client = Settings::Instance().GetNetPlayClient();
+    auto server = Settings::Instance().GetNetPlayServer();
+    if (server)
+      server->AdjustReplays(disable);
+    else
+      client->SendNightStadium(disable);
   });
 
 
@@ -550,9 +561,21 @@ void NetPlayDialog::OnRandomStadiumResult(int stadium)
 void NetPlayDialog::OnNightResult(bool is_night)
 {
   if (is_night)
+  {
     DisplayMessage(tr("Night Stadium Enabled"), "steelblue");
+  }
   else
+  {
     DisplayMessage(tr("Night Stadium Disabled"), "coral");
+  }
+}
+
+void NetPlayDialog::OnDisableReplaysResult(bool disable)
+{
+  if (disable)
+    DisplayMessage(tr("Replays Disabled"), "coral");
+  else
+    DisplayMessage(tr("Replays Enabled"), "steelblue");
 }
 
 void NetPlayDialog::DisplayActiveGeckoCodes()
@@ -686,6 +709,8 @@ void NetPlayDialog::show(std::string nickname, bool use_traversal)
   m_kick_button->setEnabled(false);
   m_night_stadium->setHidden(!is_hosting);
   m_night_stadium->setEnabled(is_hosting);
+  m_disable_replays->setHidden(!is_hosting);
+  m_disable_replays->setEnabled(is_hosting);
   //m_ranked_box->setHidden(!is_hosting);
   //m_ranked_box->setEnabled(is_hosting);
 
@@ -1004,6 +1029,7 @@ void NetPlayDialog::SetOptionsEnabled(bool enabled)
     m_fixed_delay_action->setEnabled(enabled);
     // m_ranked_box->setCheckable(enabled);
     m_night_stadium->setCheckable(enabled);
+    m_disable_replays->setCheckable(enabled);
     //m_night_stadium_action->setEnabled(enabled);
     m_disable_music_action->setEnabled(enabled);
     m_never_cull_action->setEnabled(enabled);
@@ -1049,6 +1075,7 @@ void NetPlayDialog::OnMsgStartGame()
         client->StartGame(game->GetFilePath());
         // m_ranked_box->setEnabled(false);
         m_night_stadium->setEnabled(false);
+        m_disable_replays->setEnabled(false);
       }
       else
         PanicAlertFmtT("Selected game doesn't exist in game list!");
@@ -1068,6 +1095,7 @@ void NetPlayDialog::OnMsgStopGame()
 
   const bool is_hosting = IsHosting();
   m_night_stadium->setEnabled(is_hosting);
+  m_disable_replays->setEnabled(is_hosting);
   // m_ranked_box->setEnabled(is_hosting);
   //m_ranked_box->setChecked(client->m_ranked_client);
   m_spectator_toggle->setEnabled(true);

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.cpp
@@ -267,6 +267,9 @@ void NetPlayDialog::CreateChatLayout()
   m_chat_send_button = new QPushButton(tr("Send"));
   m_coin_flipper = new QPushButton(tr("Coin Flip"));
   m_coin_flipper->setAutoDefault(false); // prevents accidental coin flips when trying to send a chat msg
+  m_random_stadium = new QPushButton(tr("Stadium"));
+  m_random_stadium->setAutoDefault(false);
+  m_random_stadium->setToolTip(tr("Generates a random stadium and posts in the netplay chat."));
 
   // This button will get re-enabled when something gets entered into the chat box
   m_chat_send_button->setEnabled(false);
@@ -281,6 +284,7 @@ void NetPlayDialog::CreateChatLayout()
   layout->addWidget(m_chat_type_edit, 1, 0);
   layout->addWidget(m_chat_send_button, 1, 1);
   layout->addWidget(m_coin_flipper, 1, 2);
+  layout->addWidget(m_random_stadium, 1, 3);
 
   m_chat_box->setLayout(layout);
 }
@@ -382,6 +386,7 @@ void NetPlayDialog::ConnectWidgets()
   connect(m_spectator_toggle, &QCheckBox::stateChanged, this, &NetPlayDialog::OnSpectatorToggle);
 
   connect(m_coin_flipper, &QPushButton::clicked, this, &NetPlayDialog::OnCoinFlip);
+  connect(m_random_stadium, &QPushButton::clicked, this, &NetPlayDialog::OnRandomStadium);
   
   const auto hia_function = [this](bool enable) {
     if (m_host_input_authority != enable)
@@ -493,6 +498,53 @@ void NetPlayDialog::OnCoinFlipResult(int coinNum)
     DisplayMessage(tr("Heads"), "lightslategray");
   else
     DisplayMessage(tr("Tails"), "lightslategray");
+}
+
+void NetPlayDialog::OnRandomStadium()
+{
+  u8 randNum;
+  randNum = rand() % 6;
+  Settings::Instance().GetNetPlayClient()->SendStadium(randNum);
+}
+
+void NetPlayDialog::OnRandomStadiumResult(int stadium)
+{
+  bool error = false;
+  u8 stadium_id = 0;
+
+  switch (stadium) {
+  case 0:
+    DisplayMessage(tr("Mario Stadium!"), "DodgerBlue");
+    break;
+  case 1:
+    DisplayMessage(tr("Peach's Garden!"), "DodgerBlue");
+    stadium_id = 4;
+    break;
+  case 2:
+    DisplayMessage(tr("Wario's Palace!"), "DodgerBlue");
+    stadium_id = 2;
+    break;
+  case 3:
+    DisplayMessage(tr("Yoshi's Park!"), "DodgerBlue");
+    stadium_id = 3;
+    break;
+  case 4:
+    DisplayMessage(tr("DK's Jungle!"), "DodgerBlue");
+    stadium_id = 5;
+    break;
+  case 5:
+    DisplayMessage(tr("Bowser's Castle!"), "DodgerBlue");
+    stadium_id = 1;
+    break;
+  default:
+    DisplayMessage(tr("There was an error. Please try again"), "red");
+    error = true;
+  }
+
+  if (error)
+    return;
+
+  Core::DefaultStadiumGecko(stadium, stadium_id);
 }
 
 void NetPlayDialog::OnNightResult(bool is_night)

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.h
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.h
@@ -79,6 +79,7 @@ public:
   void OnCoinFlipResult(int coinNum);
   void OnRandomStadiumResult(int stadium);
   void OnNightResult(bool is_night);
+  void OnDisableReplaysResult(bool disable);
   void OnActiveGeckoCodes(std::string codeStr);
   bool IsSpectating() override;
   void SetSpectating(bool spectating) override;
@@ -178,6 +179,7 @@ private:
   QPushButton* m_coin_flipper;
   QPushButton* m_random_stadium;
   QCheckBox* m_night_stadium;
+  QCheckBox* m_disable_replays;
   QCheckBox* m_spectator_toggle;
 
   QGridLayout* m_main_layout;

--- a/Source/Core/DolphinQt/NetPlay/NetPlayDialog.h
+++ b/Source/Core/DolphinQt/NetPlay/NetPlayDialog.h
@@ -77,6 +77,7 @@ public:
   void OnGameMode(std::string mode) override;
   void OnRankedEnabled(bool is_ranked) override;
   void OnCoinFlipResult(int coinNum);
+  void OnRandomStadiumResult(int stadium);
   void OnNightResult(bool is_night);
   void OnActiveGeckoCodes(std::string codeStr);
   bool IsSpectating() override;
@@ -118,6 +119,7 @@ private:
   void OnChat();
   void OnSpectatorToggle();
   void OnCoinFlip();
+  void OnRandomStadium();
   void OnStart();
   void DisplayMessage(const QString& msg, const std::string& color,
                       int duration = OSD::Duration::NORMAL);
@@ -174,6 +176,7 @@ private:
   // QCheckBox* m_ranked_box;
   QActionGroup* m_network_mode_group;
   QPushButton* m_coin_flipper;
+  QPushButton* m_random_stadium;
   QCheckBox* m_night_stadium;
   QCheckBox* m_spectator_toggle;
 

--- a/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
@@ -35,6 +35,7 @@
 #include "UICommon/NetPlayIndex.h"
 #include "DolphinQt/NetPlay/NetPlayBrowser.h"
 #include "Common/Version.h"
+#include <qdesktopservices.h>
 //#include "Core/NetPlayServer.h"
 
 
@@ -134,6 +135,7 @@ void NetPlaySetupDialog::CreateMainLayout()
   m_connection_type = new QComboBox;
   m_connection_type->setCurrentIndex(1); // default to traversal server
   m_reset_traversal_button = new NonDefaultQPushButton(tr("Reset Traversal Settings"));
+  m_latency_test = new QPushButton(tr("Internet Test"));
   m_tab_widget = new QTabWidget;
 
   m_nickname_edit->setValidator(
@@ -332,6 +334,7 @@ void NetPlaySetupDialog::CreateMainLayout()
   m_main_layout->addWidget(m_reset_traversal_button, 0, 2);
   m_main_layout->addWidget(new QLabel(tr("Nickname:")), 1, 0);
   m_main_layout->addWidget(m_nickname_edit, 1, 1);
+  m_main_layout->addWidget(m_latency_test, 1, 2);
   m_main_layout->addWidget(m_tab_widget, 2, 0, 1, -1);
   m_main_layout->addWidget(m_button_box, 3, 0, 1, -1);
 
@@ -402,6 +405,7 @@ void NetPlaySetupDialog::ConnectWidgets()
   connect(m_button_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
   connect(m_reset_traversal_button, &QPushButton::clicked, this,
           &NetPlaySetupDialog::ResetTraversalHost);
+  connect(m_latency_test, &QPushButton::clicked, this, &NetPlaySetupDialog::OpenInternetTest);
   connect(m_host_server_browser, &QCheckBox::toggled, this, [this](bool value) {
     m_host_server_region->setEnabled(value);
     m_host_server_name->setEnabled(value);
@@ -608,6 +612,12 @@ void NetPlaySetupDialog::ResetTraversalHost()
       tr("Reset Traversal Server to %1:%2")
           .arg(QString::fromStdString(Config::NETPLAY_TRAVERSAL_SERVER.GetDefaultValue()),
                QString::number(Config::NETPLAY_TRAVERSAL_PORT.GetDefaultValue())));
+}
+
+void NetPlaySetupDialog::OpenInternetTest()
+{
+  QString url = QStringLiteral("https://testmy.net/latency?testALL=1");
+  QDesktopServices::openUrl(QUrl(url));
 }
 
 

--- a/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
@@ -336,9 +336,9 @@ void NetPlaySetupDialog::CreateMainLayout()
   m_main_layout->addWidget(m_button_box, 3, 0, 1, -1);
 
   // Tabs
-  m_tab_widget->addTab(connection_widget, tr("Connect"));
-  m_tab_widget->addTab(host_widget, tr("Host"));
-  m_tab_widget->addTab(browser_widget, tr("Browser"));
+  m_tab_widget->addTab(connection_widget, tr("Join Private Lobby"));
+  m_tab_widget->addTab(host_widget, tr("Host Lobby"));
+  m_tab_widget->addTab(browser_widget, tr("Lobby Browser"));
 
 
   setLayout(m_main_layout);

--- a/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.h
+++ b/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.h
@@ -49,6 +49,7 @@ private:
   void ConnectWidgets();
   void PopulateGameList();
   void ResetTraversalHost();
+  void OpenInternetTest();
   std::string LobbyNameString();
 
   // Browser Stuff
@@ -72,6 +73,7 @@ private:
   QGridLayout* m_main_layout;
   QTabWidget* m_tab_widget;
   QPushButton* m_reset_traversal_button;
+  QPushButton* m_latency_test;
 
   // Connection Widget
   QLabel* m_ip_label;

--- a/Source/Core/VideoCommon/OnScreenDisplay.h
+++ b/Source/Core/VideoCommon/OnScreenDisplay.h
@@ -23,6 +23,7 @@ enum class MessageType
   GameStateInfo,
   GameStatePreviousPlayInfo,
   GameStatePreviousPlayResult,
+  DraftTimer,
 
   // This entry must be kept last so that persistent typed messages are
   // displayed before other messages

--- a/Source/Core/VideoCommon/VideoConfig.cpp
+++ b/Source/Core/VideoCommon/VideoConfig.cpp
@@ -64,6 +64,7 @@ void VideoConfig::Refresh()
   bShowFPS = Config::Get(Config::GFX_SHOW_FPS);
   bShowBatterFielder = Config::Get(Config::GFX_SHOW_BATTER_FIELDER);
   bTrainingModeOverlay = Config::Get(Config::GFX_TRAINING_MODE);
+  bDraftTimer = Config::Get(Config::GFX_DRAFT_TIMER);
   bShowNetPlayPing = Config::Get(Config::GFX_SHOW_NETPLAY_PING);
   bShowNetPlayMessages = Config::Get(Config::GFX_SHOW_NETPLAY_MESSAGES);
   bLogRenderTimeToFile = Config::Get(Config::GFX_LOG_RENDER_TIME_TO_FILE);

--- a/Source/Core/VideoCommon/VideoConfig.h
+++ b/Source/Core/VideoCommon/VideoConfig.h
@@ -81,6 +81,7 @@ struct VideoConfig final
   bool bShowFPS = false;
   bool bShowBatterFielder = false;
   bool bTrainingModeOverlay = false;
+  bool bDraftTimer = false;
   bool bShowNetPlayPing = false;
   bool bShowNetPlayMessages = false;
   bool bOverlayStats = false;

--- a/Source/dolphin-emu.sln
+++ b/Source/dolphin-emu.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Dolphin", "Core\DolphinQt\DolphinQt.vcxproj", "{FA3FA62B-6F58-4B86-9453-4D149940A066}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Project Rio", "Core\DolphinQt\DolphinQt.vcxproj", "{FA3FA62B-6F58-4B86-9453-4D149940A066}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DolphinNoGUI", "Core\DolphinNoGUI\DolphinNoGUI.vcxproj", "{974E563D-23F8-4E8F-9083-F62876B04E08}"
 EndProject


### PR DESCRIPTION
Major Changes:
- Hazardless stadiums and ban batter pausing added to netplay codeset
  - ranked only
- Disable Replays option in netplay

Minor Changes:
- Wiki directs to community wiki instead of dolphin wiki
- Stars off ranked doesn't unlock superstars
- Link to latency test added to Online Play Window
- Stadium Randomizer in netplay chat
- Update to Anti Quick Pitch, uses ~2 second lockout
- Validate Rio account when Online Play is opened
  - alert user that stats won't be recorded if invalid account
- Create Rio Account link added to Add Local Players window