### PR TITLE
2.0.0 Release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - "**_release"
       - "master"
-    paths-ignore:
-      - "**.md"
-      - "**.ini"
   pull_request:
     branches: 
       - "**_release"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -202,6 +202,7 @@ jobs:
           libao \
           sound-touch \
           hidapi \
+          icu4c \
           qt@6
       - name: "Build ${{ matrix.build_type }} Dolphin"
         if: success()

--- a/BuildMacOSUniversalBinary.py
+++ b/BuildMacOSUniversalBinary.py
@@ -64,7 +64,7 @@ DEFAULT_CONFIG = {
 
     # Minimum macOS version for each architecture slice
     "arm64_mac_os_deployment_target":  "11.0.0",
-    "x86_64_mac_os_deployment_target": "10.15.0",
+    "x86_64_mac_os_deployment_target": "11.0.0",
 
     # CMake Generator to use for building
     "generator": "Unix Makefiles",

--- a/BuildMacOSUniversalBinary.py
+++ b/BuildMacOSUniversalBinary.py
@@ -64,7 +64,7 @@ DEFAULT_CONFIG = {
 
     # Minimum macOS version for each architecture slice
     "arm64_mac_os_deployment_target":  "11.0.0",
-    "x86_64_mac_os_deployment_target": "11.0.0",
+    "x86_64_mac_os_deployment_target": "10.15.0",
 
     # CMake Generator to use for building
     "generator": "Unix Makefiles",

--- a/CMake/DolphinPostprocessBundle.cmake
+++ b/CMake/DolphinPostprocessBundle.cmake
@@ -28,6 +28,11 @@ message(STATUS "Fixing up application bundle: ${DOLPHIN_BUNDLE_PATH}")
 # needed.
 file(GLOB_RECURSE extra_libs "${DOLPHIN_BUNDLE_PATH}/Contents/MacOS/*.dylib")
 
+# Iterate through the list of paths in extra_libs and print each one
+foreach(lib_path ${extra_libs})
+    message(STATUS "Found library: ${lib_path}")
+endforeach()
+
 # BundleUtilities doesn't support DYLD_FALLBACK_LIBRARY_PATH behavior, which
 # makes it sometimes break on libraries that do weird things with @rpath. Specify
 # equivalent search directories until https://gitlab.kitware.com/cmake/cmake/issues/16625

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,7 +133,7 @@ endif()
 
 if(APPLE)
   option(MACOS_USE_DEFAULT_SEARCH_PATH "Don't prioritize system library paths" OFF)
-  option(SKIP_POSTPROCESS_BUNDLE "Skip postprocessing bundle for redistributability" ON)
+  option(SKIP_POSTPROCESS_BUNDLE "Skip postprocessing bundle for redistributability" OFF)
   # Enable adhoc code signing by default (otherwise makefile builds on ARM will not work)
   option(MACOS_CODE_SIGNING "Enable codesigning" ON)
   option(USE_BUNDLED_MOLTENVK "Build MoltenVK from Externals with Dolphin-specific patches" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,7 +133,7 @@ endif()
 
 if(APPLE)
   option(MACOS_USE_DEFAULT_SEARCH_PATH "Don't prioritize system library paths" OFF)
-  option(SKIP_POSTPROCESS_BUNDLE "Skip postprocessing bundle for redistributability" OFF)
+  option(SKIP_POSTPROCESS_BUNDLE "Skip postprocessing bundle for redistributability" ON)
   # Enable adhoc code signing by default (otherwise makefile builds on ARM will not work)
   option(MACOS_CODE_SIGNING "Enable codesigning" ON)
   option(USE_BUNDLED_MOLTENVK "Build MoltenVK from Externals with Dolphin-specific patches" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 
 # Minimum OS X version.
 # This is inserted into the Info.plist as well.
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15.0" CACHE STRING "")
+set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0.0" CACHE STRING "")
 
 set(CMAKE_USER_MAKE_RULES_OVERRIDE "CMake/FlagsOverride.cmake")
 

--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,7 @@ Please read the [FAQ](https://dolphin-emu.org/docs/faq/) before using Dolphin.
 * OS
     * Windows (10 or higher).
     * Linux.
-    * macOS (10.15 Catalina or higher).
+    * macOS (11.0 Catalina or higher).
     * Unix-like systems other than Linux are not officially supported but might work.
 * Processor
     * A CPU with SSE2 support.
@@ -251,4 +251,4 @@ then exit.
   -l, --compression_level
                         Optional. Print the level of compression for WIA/RVZ
                         formats, then exit.
-```
+``` 

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -342,8 +342,23 @@ void MSSBCalculateNextGolfer(const Core::CPUThreadGuard& guard, int& nextGolfer)
 
 void MGTTCalculateNextGolfer(const Core::CPUThreadGuard& guard, int& nextGolfer)
 {
-  // u8 playerCount = PowerPC::MMU::HostRead_U8(guard, aPlayerCount);
-  nextGolfer = PowerPC::MMU::HostRead_U8(guard, aCurrentGolfer);
+  u8 golferIndex = PowerPC::MMU::HostRead_U8(guard, aCurrentGolfer);
+  switch(golferIndex) {
+    case 0:
+      nextGolfer = PowerPC::MMU::HostRead_U8(guard, aPlayer1Port);
+      break;
+    case 1: 
+      nextGolfer = PowerPC::MMU::HostRead_U8(guard, aPlayer2Port);
+      break;
+    case 2:
+      nextGolfer = PowerPC::MMU::HostRead_U8(guard, aPlayer3Port);
+      break;
+    case 3:
+      nextGolfer = PowerPC::MMU::HostRead_U8(guard, aPlayer4Port);
+      break;
+    default:
+      break;
+  }
 }
 
 bool IsGolfMode()

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -343,23 +343,7 @@ void MSSBCalculateNextGolfer(const Core::CPUThreadGuard& guard, int& nextGolfer)
 void MGTTCalculateNextGolfer(const Core::CPUThreadGuard& guard, int& nextGolfer)
 {
   // u8 playerCount = PowerPC::MMU::HostRead_U8(guard, aPlayerCount);
-  u8 golferIndex = PowerPC::MMU::HostRead_U8(guard, aCurrentGolfer);
-  switch(golferIndex) {
-    case 0:
-      nextGolfer = PowerPC::MMU::HostRead_U8(guard, aPlayer1Port);
-      break;
-    case 1: 
-      nextGolfer = PowerPC::MMU::HostRead_U8(guard, aPlayer2Port);
-      break;
-    case 2:
-      nextGolfer = PowerPC::MMU::HostRead_U8(guard, aPlayer3Port);
-      break;
-    case 3:
-      nextGolfer = PowerPC::MMU::HostRead_U8(guard, aPlayer4Port);
-      break;
-    default:
-      break;
-  }
+  nextGolfer = PowerPC::MMU::HostRead_U8(guard, aCurrentGolfer);
 }
 
 bool IsGolfMode()

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -378,169 +378,221 @@ void TrainingMode(const Core::CPUThreadGuard& guard)
   if (!g_ActiveConfig.bTrainingModeOverlay || isTagSetActive())
     return;
 
-  if (mGameBeingPlayed != GameName::MarioBaseball)
-    return;
-
-  //bool isPitchThrown = PowerPC::MMU::HostRead_U8(0x80895D6C) == 1 ? true : false;
-  bool isField = PowerPC::MMU::HostRead_U8(guard, aIsField) == 1 ? true : false;
-  bool isInGame = PowerPC::MMU::HostRead_U8(guard, aIsInGame) == 1 ? true : false;
-  bool ContactMade = PowerPC::MMU::HostRead_U8(guard, aContactMade) == 1 ? true : false;
-
-  // Batting Training Mode stats
-  if (ContactMade && !previousContactMade)
+  if (mGameBeingPlayed == GameName::MarioBaseball)
   {
-    u8 BatterPort = PowerPC::MMU::HostRead_U8(guard, aBatterPort);
-    if (BatterPort > 0)
-      BatterPort--;
-    u32 stickDirectionAddr = 0x8089392D + (0x10 * BatterPort);
-    float contactQuality = PowerPC::MMU::HostRead_F32(guard, aAB_ContactQuality);
-    u16 contactFrame = PowerPC::MMU::HostRead_U16(guard, aContactFrame);
-    u8 typeOfContact_Value = PowerPC::MMU::HostRead_U8(guard, aTypeOfContact);
-    std::string typeOfContact;
-    u8 inputDirection_Value = PowerPC::MMU::HostRead_U8(guard, stickDirectionAddr) & 0xF;
-    std::string inputDirection;
-    int chargeUp = static_cast<int>(roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, aChargeUp)) * 100)); 
-    int chargeDown = static_cast<int>(roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, aChargeDown)) * 100));
+    // bool isPitchThrown = PowerPC::MMU::HostRead_U8(0x80895D6C) == 1 ? true : false;
+    bool isField = PowerPC::MMU::HostRead_U8(guard, aIsField) == 1 ? true : false;
+    bool isInGame = PowerPC::MMU::HostRead_U8(guard, aIsInGame) == 1 ? true : false;
+    bool ContactMade = PowerPC::MMU::HostRead_U8(guard, aContactMade) == 1 ? true : false;
 
-    float angle = roundf((float)PowerPC::MMU::HostRead_U16(guard, aBallAngle) * 36000 / 4096) / 100; // 0x400 == 90°, 0x800 == 180°, 0x1000 == 360°
-    float xVelocity = roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, aBallVelocity_X)) * 6000) / 100;  // * 60 cause default units are meters per frame
-    float yVelocity = roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, aBallVelocity_Y)) * 6000) / 100;
-    float zVelocity = roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, aBallVelocity_Z)) * 6000) / 100;
-    float netVelocity = vectorMagnitude(xVelocity, yVelocity, zVelocity);
+    // Batting Training Mode stats
+    if (ContactMade && !previousContactMade)
+    {
+      u8 BatterPort = PowerPC::MMU::HostRead_U8(guard, aBatterPort);
+      if (BatterPort > 0)
+        BatterPort--;
+      u32 stickDirectionAddr = 0x8089392D + (0x10 * BatterPort);
+      float contactQuality = PowerPC::MMU::HostRead_F32(guard, aAB_ContactQuality);
+      u16 contactFrame = PowerPC::MMU::HostRead_U16(guard, aContactFrame);
+      u8 typeOfContact_Value = PowerPC::MMU::HostRead_U8(guard, aTypeOfContact);
+      std::string typeOfContact;
+      u8 inputDirection_Value = PowerPC::MMU::HostRead_U8(guard, stickDirectionAddr) & 0xF;
+      std::string inputDirection;
+      int chargeUp =
+          static_cast<int>(roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, aChargeUp)) * 100));
+      int chargeDown = static_cast<int>(
+          roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, aChargeDown)) * 100));
 
-    // convert type of contact to string
-    if (typeOfContact_Value == 0)
-      typeOfContact = "Sour - Left";
-    else if (typeOfContact_Value == 1)
-      typeOfContact = "Nice - Left";
-    else if (typeOfContact_Value == 2)
-      typeOfContact = "Perfect";
-    else if (typeOfContact_Value == 3)
-      typeOfContact = "Nice - Right";
-    else  // typeOfContact_Value == 4
-      typeOfContact = "Sour - Right";
+      float angle = roundf((float)PowerPC::MMU::HostRead_U16(guard, aBallAngle) * 36000 / 4096) /
+                    100;  // 0x400 == 90°, 0x800 == 180°, 0x1000 == 360°
+      float xVelocity =
+          roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, aBallVelocity_X)) * 6000) /
+          100;  // * 60 cause default units are meters per frame
+      float yVelocity =
+          roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, aBallVelocity_Y)) * 6000) / 100;
+      float zVelocity =
+          roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, aBallVelocity_Z)) * 6000) / 100;
+      float netVelocity = vectorMagnitude(xVelocity, yVelocity, zVelocity);
 
-    // convert input direction to string
-    if (inputDirection_Value == 0)
-      inputDirection = "None";
-    else if (inputDirection_Value == 1)
-      inputDirection = "Left";
-    else if (inputDirection_Value == 2)
-      inputDirection = "Right";
-    else if (inputDirection_Value == 4)
-      inputDirection = "Down";
-    else if (inputDirection_Value == 8)
-      inputDirection = "Up";
-    else if (inputDirection_Value == 5)
-      inputDirection = "Down/Left";
-    else if (inputDirection_Value == 9)
-      inputDirection = "Up/Left";
-    else if (inputDirection_Value == 6)
-      inputDirection = "Down/Right";
-    else if (inputDirection_Value == 10)
-      inputDirection = "Up/Right";
-    else if (inputDirection_Value == 3)
-      inputDirection = "Left/Right";
-    else if (inputDirection_Value == 12)
-      inputDirection = "Up/Down";
-    else
-      inputDirection = "Unknown";
+      // convert type of contact to string
+      if (typeOfContact_Value == 0)
+        typeOfContact = "Sour - Left";
+      else if (typeOfContact_Value == 1)
+        typeOfContact = "Nice - Left";
+      else if (typeOfContact_Value == 2)
+        typeOfContact = "Perfect";
+      else if (typeOfContact_Value == 3)
+        typeOfContact = "Nice - Right";
+      else  // typeOfContact_Value == 4
+        typeOfContact = "Sour - Right";
 
-    int totalCharge;
-    chargeUp == 100 ? totalCharge = chargeDown : totalCharge = chargeUp;
+      // convert input direction to string
+      if (inputDirection_Value == 0)
+        inputDirection = "None";
+      else if (inputDirection_Value == 1)
+        inputDirection = "Left";
+      else if (inputDirection_Value == 2)
+        inputDirection = "Right";
+      else if (inputDirection_Value == 4)
+        inputDirection = "Down";
+      else if (inputDirection_Value == 8)
+        inputDirection = "Up";
+      else if (inputDirection_Value == 5)
+        inputDirection = "Down/Left";
+      else if (inputDirection_Value == 9)
+        inputDirection = "Up/Left";
+      else if (inputDirection_Value == 6)
+        inputDirection = "Down/Right";
+      else if (inputDirection_Value == 10)
+        inputDirection = "Up/Right";
+      else if (inputDirection_Value == 3)
+        inputDirection = "Left/Right";
+      else if (inputDirection_Value == 12)
+        inputDirection = "Up/Down";
+      else
+        inputDirection = "Unknown";
 
-    OSD::AddTypedMessage(OSD::MessageType::TrainingModeBatting, fmt::format(
-      "Batting Data:                    \n"
-      "Contact Frame:  {}\n"
-      "Type of Contact:  {}\n"
-      "Contact Quality: {}\n"
-      "Input Direction:  {}\n"
-      "Charge Percent:  {}%\n"
-      "Ball Angle:  {}°\n\n"
-      "Exit Velocities:  \n"
-      "X :  {} m/s  -->  {} mph\n"
-      "Y:  {} m/s  -->  {} mph\n"
-      "Z :  {} m/s  -->  {} mph\n"
-      "Net:  {} m/s  -->  {} mph",
-      contactFrame,
-      typeOfContact,
-      contactQuality,
-      inputDirection,
-      totalCharge,
-      angle,
-      xVelocity, ms_to_mph(xVelocity),
-      yVelocity, ms_to_mph(yVelocity),
-      zVelocity, ms_to_mph(zVelocity),
-      netVelocity, ms_to_mph(netVelocity)),
-      8000); // message time & color
+      int totalCharge;
+      chargeUp == 100 ? totalCharge = chargeDown : totalCharge = chargeUp;
+
+      OSD::AddTypedMessage(OSD::MessageType::TrainingModeBatting,
+                           fmt::format("Batting Data:                    \n"
+                                       "Contact Frame:  {}\n"
+                                       "Type of Contact:  {}\n"
+                                       "Contact Quality: {}\n"
+                                       "Input Direction:  {}\n"
+                                       "Charge Percent:  {}%\n"
+                                       "Ball Angle:  {}°\n\n"
+                                       "Exit Velocities:  \n"
+                                       "X :  {} m/s  -->  {} mph\n"
+                                       "Y:  {} m/s  -->  {} mph\n"
+                                       "Z :  {} m/s  -->  {} mph\n"
+                                       "Net:  {} m/s  -->  {} mph",
+                                       contactFrame, typeOfContact, contactQuality, inputDirection,
+                                       totalCharge, angle, xVelocity, ms_to_mph(xVelocity),
+                                       yVelocity, ms_to_mph(yVelocity), zVelocity,
+                                       ms_to_mph(zVelocity), netVelocity, ms_to_mph(netVelocity)),
+                           8000);  // message time & color
     }
 
+    // Coordinate data
+    if (isInGame)
+    {
+      float BallPos_X =
+          roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, aBallPosition_X)) * 100) / 100;
+      float BallPos_Y =
+          roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, aBallPosition_Y)) * 100) / 100;
+      float BallPos_Z =
+          roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, aBallPosition_Z)) * 100) / 100;
+      float BallVel_X =
+          isField ?
+              roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, aBallVelocity_X)) * 6000) / 100 :
+              roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, aPitchedBallVelocity_X)) * 6000) /
+                  100;
+      float BallVel_Y =
+          isField ? RoundZ(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, aBallVelocity_Y)) * 6000) /
+                        100 :  // floor small decimal to prevent weirdness
+              RoundZ(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, aPitchedBallVelocity_Y)) * 6000) /
+                  100;
+      float BallVel_Z =
+          isField ?
+              roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, aBallVelocity_Z)) * 6000) / 100 :
+              roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, aPitchedBallVelocity_Z)) * 6000) /
+                  100;
+      float BallVel_Net = roundf(vectorMagnitude(BallVel_X, BallVel_Y, BallVel_Z) * 100) / 100;
 
-  // Coordinate data
-  if (isInGame)
-  {
-    float BallPos_X = roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, aBallPosition_X)) * 100) / 100;
-    float BallPos_Y = roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, aBallPosition_Y)) * 100) / 100;
-    float BallPos_Z = roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, aBallPosition_Z)) * 100) / 100;
-    float BallVel_X = isField ? roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, aBallVelocity_X)) * 6000) / 100 :
-                                roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, aPitchedBallVelocity_X)) * 6000) / 100;
-    float BallVel_Y = isField ? RoundZ(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, aBallVelocity_Y)) * 6000) / 100 :// floor small decimal to prevent weirdness
-                                RoundZ(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, aPitchedBallVelocity_Y)) * 6000) / 100;
-    float BallVel_Z = isField ? roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, aBallVelocity_Z)) * 6000) / 100 :
-                                roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, aPitchedBallVelocity_Z)) * 6000) / 100;
-    float BallVel_Net = roundf(vectorMagnitude(BallVel_X, BallVel_Y, BallVel_Z) * 100) / 100;
+      int baseOffset = 0x268 * PowerPC::MMU::HostRead_U8(
+                                   guard, 0x80892801);  // used to get offsed for baseFielderAddr
+      u32 baseFielderAddr = 0x8088F368 + baseOffset;    // 0x0 == x; 0x8 == y; 0xc == z
 
-    int baseOffset= 0x268 * PowerPC::MMU::HostRead_U8(guard, 0x80892801);  // used to get offsed for baseFielderAddr
-    u32 baseFielderAddr = 0x8088F368 + baseOffset;        // 0x0 == x; 0x8 == y; 0xc == z
+      float FielderPos_X =
+          roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, baseFielderAddr)) * 100) / 100;
+      float FielderPos_Y =
+          roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, baseFielderAddr + 0xc)) * 100) / 100;
+      float FielderPos_Z =
+          roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, baseFielderAddr + 0x8)) * 100) / 100;
+      float FielderVel_X =
+          roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, baseFielderAddr + 0x30)) * 6000) /
+          100;
+      // float FielderVel_Y = roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(baseFielderAddr + 0x15C))
+      // * 6000) / 100; // this addr is wrong
+      float FielderVel_Z =
+          roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, baseFielderAddr + 0x34)) * 6000) /
+          100;
+      float FielderVel_Net =
+          roundf(vectorMagnitude(FielderVel_X, 0 /*FielderVel_Y*/, FielderVel_Z) * 100) / 100;
 
-    float FielderPos_X = roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, baseFielderAddr)) * 100) / 100;
-    float FielderPos_Y = roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, baseFielderAddr + 0xc)) * 100) / 100;
-    float FielderPos_Z = roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, baseFielderAddr + 0x8)) * 100) / 100;
-    float FielderVel_X = roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, baseFielderAddr + 0x30)) * 6000) / 100;
-    //float FielderVel_Y = roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(baseFielderAddr + 0x15C)) * 6000) / 100; // this addr is wrong
-    float FielderVel_Z = roundf(u32ToFloat(PowerPC::MMU::HostRead_U32(guard, baseFielderAddr + 0x34)) * 6000) / 100;
-    float FielderVel_Net = roundf(vectorMagnitude(FielderVel_X, 0 /*FielderVel_Y*/, FielderVel_Z) * 100) / 100;
+      OSD::AddTypedMessage(
+          OSD::MessageType::TrainingModeBallCoordinates,
+          fmt::format("Ball Coordinates:                \n"
+                      "X:  {}\n"
+                      "Y:  {}\n"
+                      "Z:  {}\n\n"
+                      "Ball Velocity:  \n"
+                      "X:  {} m/s  -->  {} mph\n"
+                      "Y:  {} m/s  -->  {} mph\n"
+                      "Z:  {} m/s  -->  {} mph\n"
+                      "Net:  {} m/s  -->  {} mph\n",
+                      BallPos_X, BallPos_Y, BallPos_Z, BallVel_X, ms_to_mph(BallVel_X), BallVel_Y,
+                      ms_to_mph(BallVel_Y), BallVel_Z, ms_to_mph(BallVel_Z), BallVel_Net,
+                      ms_to_mph(BallVel_Net)),
+          200, OSD::Color::CYAN);  // short time cause we don't want this info to linger
 
-    OSD::AddTypedMessage(OSD::MessageType::TrainingModeBallCoordinates, fmt::format(
-      "Ball Coordinates:                \n"
-      "X:  {}\n"
-      "Y:  {}\n"
-      "Z:  {}\n\n"
-      "Ball Velocity:  \n"
-      "X:  {} m/s  -->  {} mph\n"
-      "Y:  {} m/s  -->  {} mph\n"
-      "Z:  {} m/s  -->  {} mph\n"
-      "Net:  {} m/s  -->  {} mph\n",
-      BallPos_X,
-      BallPos_Y,
-      BallPos_Z,
-      BallVel_X, ms_to_mph(BallVel_X),
-      BallVel_Y, ms_to_mph(BallVel_Y),
-      BallVel_Z, ms_to_mph(BallVel_Z),
-      BallVel_Net, ms_to_mph(BallVel_Net)
-    ), 200, OSD::Color::CYAN);  // short time cause we don't want this info to linger
+      OSD::AddTypedMessage(OSD::MessageType::TrainingModeFielderCoordinates,
+                           fmt::format("Fielder Coordinates:             \n"
+                                       "X:  {}\n"
+                                       "Y:  {}\n"
+                                       "Z:  {}\n\n"
+                                       "Fielder Velocity: \n"
+                                       "X:  {} m/s  -->  {} mph\n"
+                                       //"Y:  {} m/s  -->  {} mph\n"
+                                       "Z:  {} m/s  -->  {} mph\n"
+                                       "Net:  {} m/s  -->  {} mph",
+                                       FielderPos_X, FielderPos_Y, FielderPos_Z, FielderVel_X,
+                                       ms_to_mph(FielderVel_X),
+                                       // FielderVel_Y, ms_to_mph(FielderVel_Y),
+                                       FielderVel_Z, ms_to_mph(FielderVel_Z), FielderVel_Net,
+                                       ms_to_mph(FielderVel_Net)),
+                           200, OSD::Color::CYAN);
+    }
 
-    OSD::AddTypedMessage(OSD::MessageType::TrainingModeFielderCoordinates, fmt::format(
-      "Fielder Coordinates:             \n"
-      "X:  {}\n"
-      "Y:  {}\n"
-      "Z:  {}\n\n"
-      "Fielder Velocity: \n"
-      "X:  {} m/s  -->  {} mph\n"
-      //"Y:  {} m/s  -->  {} mph\n"
-      "Z:  {} m/s  -->  {} mph\n"
-      "Net:  {} m/s  -->  {} mph",
-      FielderPos_X,
-      FielderPos_Y,
-      FielderPos_Z,
-      FielderVel_X, ms_to_mph(FielderVel_X),
-      //FielderVel_Y, ms_to_mph(FielderVel_Y),
-      FielderVel_Z, ms_to_mph(FielderVel_Z),
-      FielderVel_Net, ms_to_mph(FielderVel_Net)
-    ), 200, OSD::Color::CYAN);
+    previousContactMade = ContactMade;
   }
+  else if (mGameBeingPlayed == GameName::ToadstoolTour)
+  {
+    float DistanceRemainingToHole = PowerPC::MMU::HostRead_F32(guard, aDistanceRemainingToHole);
+    int ShotAccuracy = PowerPC::MMU::HostRead_U32(guard, aShotAccuracy);
+    u32 PowerMeterDistance = PowerPC::MMU::HostRead_U32(guard, aPowerMeterDistance);
+    float CurrentShotAimAngle = PowerPC::MMU::HostRead_F32(guard, aCurrentShotAimAngle);
+    float SimLineEndpointX = PowerPC::MMU::HostRead_F32(guard, aSimLineEndpointX);
+    float SimLineEndpointZ = PowerPC::MMU::HostRead_F32(guard, aSimLineEndpointZ);
+    float SimLineEndpointY = PowerPC::MMU::HostRead_F32(guard, aSimLineEndpointY);
+    int PreShotVerticalAdjustment = PowerPC::MMU::HostRead_U32(guard, aPreShotVerticalAdjustment);
+    int PreShotHorizontalAdjustment =
+        PowerPC::MMU::HostRead_U32(guard, aPreShotHorizontalAdjustment);
+    int ActiveShotVerticalAdjustment =
+        PowerPC::MMU::HostRead_U32(guard, aActiveShotVerticalAdjustment);
+    int ActiveShotHorizontalAdjustment =
+        PowerPC::MMU::HostRead_U32(guard, aActiveShotHorizontalAdjustment);
 
-  previousContactMade = ContactMade;
+    OSD::AddTypedMessage(OSD::MessageType::TrainingModeGolfing,
+                         fmt::format("Golf Training Mode:                    \n"
+                                     "Distance to Hole:  {}\n"
+                                     "Shot Aim Angle:  {}\n"
+                                     "Vertical Adj:  {} / {}\n"
+                                     "Horizontal Adj:  {} / {}\n"
+                                     "Shot Accuracy:  {}\n"
+                                     "Power Meter Accuracy:  {}\n"
+                                     "Ball Sim Aim X:  {}\n"
+                                     "Ball Sim Aim Y:  {}\n"
+                                     "Ball Sim Aim Z:  {}\n",
+                                     DistanceRemainingToHole, CurrentShotAimAngle,
+                                     PreShotVerticalAdjustment, ActiveShotVerticalAdjustment,
+                                     PreShotHorizontalAdjustment, ActiveShotHorizontalAdjustment,
+                                     ShotAccuracy, PowerMeterDistance, SimLineEndpointX,
+                                     SimLineEndpointY, SimLineEndpointZ),
+                         8000);  // message time & color
+  }
 }
 
 void DisplayPlayerNames(const Core::CPUThreadGuard& guard)
@@ -610,6 +662,23 @@ void DisplayPlayerNames(const Core::CPUThreadGuard& guard)
       break;
 
     u8 GolferPort = PowerPC::MMU::HostRead_U8(guard, aCurrentGolfer);
+    switch (GolferPort)
+    {
+    case 0:
+      GolferPort = PowerPC::MMU::HostRead_U8(guard, aPlayer1Port);
+      break;
+    case 1:
+      GolferPort = PowerPC::MMU::HostRead_U8(guard, aPlayer2Port);
+      break;
+    case 2:
+      GolferPort = PowerPC::MMU::HostRead_U8(guard, aPlayer3Port);
+      break;
+    case 3:
+      GolferPort = PowerPC::MMU::HostRead_U8(guard, aPlayer4Port);
+      break;
+    default:
+      break;
+    }
     std::string GolferName = "";
 
     if (NetPlay::IsNetPlayRunning())

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -281,8 +281,11 @@ static const u32 aWhoPaused = 0x8039D7D3; // 2 == fielder, 1 == batter
 //static const u32 aMatchStarted = 0x8036F3B8;  // bool for if a game is in session
 static const u32 aSceneId = 0x800E877F;
 
-
-static const u32 aCurrentGolfer = 0x804E68FB; // 0-3, indicates current golfing player
+static const u32 aCurrentGolfer = 0x804E68FB; // 0-3, indicates current golfing player index
+static const u32 aPlayer1Port = 0x804E6674; 
+static const u32 aPlayer2Port = 0x804E6675;
+static const u32 aPlayer3Port = 0x804E6676; 
+static const u32 aPlayer4Port = 0x804E6677; 
 static const u32 aPlayerCount = 0x804E68FA; // indicates total player count
 static const u32 aIsGolfMatch = 0x80162B5F; // 1 if golfing session active; 0 on menus
 }  // namespace Core

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -282,13 +282,7 @@ static const u32 aWhoPaused = 0x8039D7D3; // 2 == fielder, 1 == batter
 static const u32 aSceneId = 0x800E877F;
 
 
-static const u32 aCurrentGolfer = 0x804E68FB; // 0-3, indicates current golfing player index
-static const u32 aPlayer1Port = 0x804E6674; 
-static const u32 aPlayer2Port = 0x804E6675;
-static const u32 aPlayer3Port = 0x804E6676; 
-static const u32 aPlayer4Port = 0x804E6677; 
-
-
+static const u32 aCurrentGolfer = 0x804E68FB; // 0-3, indicates current golfing player
 static const u32 aPlayerCount = 0x804E68FA; // indicates total player count
 static const u32 aIsGolfMatch = 0x80162B5F; // 1 if golfing session active; 0 on menus
 }  // namespace Core

--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -281,6 +281,18 @@ static const u32 aWhoPaused = 0x8039D7D3; // 2 == fielder, 1 == batter
 //static const u32 aMatchStarted = 0x8036F3B8;  // bool for if a game is in session
 static const u32 aSceneId = 0x800E877F;
 
+// toadstooltour addresses
+static const u32 aDistanceRemainingToHole = 0x802D7368;
+static const u32 aShotAccuracy = 0x804ECD30;
+static const u32 aPowerMeterDistance = 0x804ECD54;
+static const u32 aCurrentShotAimAngle = 0x804ECD5C;  // radians
+static const u32 aSimLineEndpointX = 0x804ECD70;
+static const u32 aSimLineEndpointZ = 0x804ECD74;
+static const u32 aSimLineEndpointY = 0x804ECD78;
+static const u32 aPreShotVerticalAdjustment = 0x804ECDA0;
+static const u32 aPreShotHorizontalAdjustment = 0x804ECDA4;
+static const u32 aActiveShotVerticalAdjustment = 0x804ECDA8;
+static const u32 aActiveShotHorizontalAdjustment = 0x804ECDAC;
 static const u32 aCurrentGolfer = 0x804E68FB; // 0-3, indicates current golfing player index
 static const u32 aPlayer1Port = 0x804E6674; 
 static const u32 aPlayer2Port = 0x804E6675;

--- a/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
@@ -579,7 +579,6 @@ void NetPlaySetupDialog::show()
   RefreshBrowser();
 
   PopulateGameList();
-  CheckGameModesAreAllowed();
   QDialog::show();
 }
 

--- a/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
@@ -579,6 +579,7 @@ void NetPlaySetupDialog::show()
   RefreshBrowser();
 
   PopulateGameList();
+  CheckGameModesAreAllowed();
   QDialog::show();
 }
 

--- a/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
+++ b/Source/Core/DolphinQt/NetPlay/NetPlaySetupDialog.cpp
@@ -563,6 +563,14 @@ void NetPlaySetupDialog::UpdateGameModeDescription()
 
 void NetPlaySetupDialog::CheckGameModesAreAllowed()
 {
+  int currentIndex = m_host_games->currentIndex();
+  if (currentIndex < 0 || currentIndex >= m_host_games->count())
+  {
+    m_host_game_mode->setCurrentIndex(0);
+    m_host_game_mode->setDisabled(true);
+    return;
+  }
+
   std::string game_id = host_games_map.at(m_host_games->currentIndex()).GetGameID();
   if (game_id == "GYQE01")
     m_host_game_mode->setEnabled(true);

--- a/Source/Core/VideoCommon/OnScreenDisplay.h
+++ b/Source/Core/VideoCommon/OnScreenDisplay.h
@@ -24,6 +24,7 @@ enum class MessageType
   GameStatePreviousPlayInfo,
   GameStatePreviousPlayResult,
   DraftTimer,
+  TrainingModeGolfing,
 
   // This entry must be kept last so that persistent typed messages are
   // displayed before other messages

--- a/build-mac.sh
+++ b/build-mac.sh
@@ -2,7 +2,7 @@
 # build-mac.sh
 
 QT_BREW_PATH=$(brew --prefix qt@6)
-CMAKE_FLAGS="-DQt6_DIR=${QT_BREW_PATH}/lib/cmake/Qt6 -DENABLE_NOGUI=false"
+CMAKE_FLAGS="-DQT_DIR=${QT_BREW_PATH}/lib/cmake/Qt5 -DENABLE_NOGUI=false"
 
 DATA_SYS_PATH="./Data/Sys/"
 BINARY_PATH="./build/Binaries/Dolphin.app/Contents/Resources/"
@@ -22,7 +22,7 @@ fi
 mkdir -p build
 pushd build
 cmake ${CMAKE_FLAGS} ..
-make -j7
+cmake --build . --target dolphin-emu -- -j$(nproc)
 popd
 
 # Copy the Sys folder in

--- a/build-mac.sh
+++ b/build-mac.sh
@@ -19,7 +19,6 @@ else
 fi
 
 # Move into the build directory, run CMake, and compile the project
-brew reinstall icu4c
 mkdir -p build
 pushd build
 cmake ${CMAKE_FLAGS} ..

--- a/build-mac.sh
+++ b/build-mac.sh
@@ -19,6 +19,7 @@ else
 fi
 
 # Move into the build directory, run CMake, and compile the project
+brew reinstall icu4c
 mkdir -p build
 pushd build
 cmake ${CMAKE_FLAGS} ..

--- a/build-mac.sh
+++ b/build-mac.sh
@@ -2,7 +2,7 @@
 # build-mac.sh
 
 QT_BREW_PATH=$(brew --prefix qt@6)
-CMAKE_FLAGS="-DQT_DIR=${QT_BREW_PATH}/lib/cmake/Qt5 -DENABLE_NOGUI=false"
+CMAKE_FLAGS="-DQt6_DIR=${QT_BREW_PATH}/lib/cmake/Qt6 -DENABLE_NOGUI=false"
 
 DATA_SYS_PATH="./Data/Sys/"
 BINARY_PATH="./build/Binaries/Dolphin.app/Contents/Resources/"


### PR DESCRIPTION
### Project Rio 2.0 Changes

## Client Enhancements:
Updated the Project Rio client to be in sync with the main line development branch of Dolphin.
This mostly results in under the hood enhancements, but a big user enhancement is the addition of the Metal graphics backend for Mac users!

## Mario Superstar Baseball:
Added a “Captain Re select” client code
On the team select screen, press start on a captain character to assign them as your team captain
This currently does have some limitations, such as:
Team stars will not update until an additional character is selected after you complete a captain swap. You will briefly see the correct stars when you press start on the new captain however.
Background graphics will not update. You will hear a “swoosh” sound effect to confirm when you have swapped a captain with the start button

## Mario Golf: Toadstool Tour
The Project Rio client now reads and supports Mario Golf: Toadstool Tour
Auto-golf is implemented for Netplay
Modes/gameplay with each character assigned to a unique character is fully supported
Modes/gameplay that have characters sharing a team or controller (ex assign two characters to a single controller, doubles, etc.) is in an experimental phase. Please report any visual or auto golf bugs to the team if you encounter them!
A training graphic is available under Graphics > General
The graphic displays some variables from the in-game memory as you play. Helpful for practicing!
Basic gecko codes included (to aid Netplay experience):
Skip memory card check
Allow duplicate characters
Shot speed up

Thanks for all the Clutch1908 for the write up.