### PR TITLE
Auto Golf Rework

### DIFF
--- a/Source/Core/Core/Core.h
+++ b/Source/Core/Core/Core.h
@@ -221,6 +221,7 @@ void DoFrameStep();
 void UpdateInputGate(bool require_focus, bool require_full_focus = false);
 
 void UpdateTitle();
+
 float u32ToFloat(u32 value);
 float ms_to_mph(float MetersPerSecond);
 float vectorMagnitude(float x, float y, float z);
@@ -236,6 +237,7 @@ void DisplayPlayerNames(const Core::CPUThreadGuard& guard);
 void SetAvgPing(const Core::CPUThreadGuard& guard);
 void SetNetplayerUserInfo();
 void RunDraftTimer(const Core::CPUThreadGuard& guard);
+int GetNextGolferID();
 
 //enum class GameMode
 //{

--- a/Source/Core/Core/NetPlayClient.h
+++ b/Source/Core/Core/NetPlayClient.h
@@ -199,7 +199,6 @@ public:
   static void SendChecksum(u8 checksumId, u64 frame, u32 checksum);
   bool DoAllPlayersHaveGame();
 
-  static void AutoGolfMode(int nextGolfer);
   static std::string GetNetplayNames(u8 PortInt);
   static bool isNight();
   static bool isDisableReplays();
@@ -316,7 +315,7 @@ private:
   void ComputeGameDigest(const SyncIdentifier& sync_identifier);
   void DisplayPlayersPing();
 
-  void AutoGolfModeLogic(int nextGolfer);
+  void AutoGolfMode();
 
   u32 GetPlayersMaxPing() const;
 


### PR DESCRIPTION
I'm changing the flow of how Auto Golf Mode will work.

Originally, it was set up where a function on the CPU thread would read the game's ram, calculate which port should be golfer, and then call a static NetPlayClient function, which would then call a private NetPlayClient function, which would do some magic before calling RequestGolfer function.

A potential issue lies in calling NetPlayClient functions through static function calls while on the CPU thread. I _think_ that this on top of the freezing associated with executing a golfer swap COMBINED with the fact that this is technically running on the CPU thread is what's causing Auto Golf Mode-related freezes.

This new system addresses this issue. The CPU thread will still read the ram and calculate the next golfer, but it will then in turn store it in a variable which can be accessed with at getter public function in Core.cpp. On a different thread within the Netplay while loop (the one that processes netplay commuinication) will handle the golfer swaps. It will first check if the CPU thread is active, since if it is active there could be a potential memory access exception _(if Core tries to update the Next Golfer Id variable while NetPlayClient tried to read it)_. If it's not active, it will then get that value and run the golf mode function which determined if a golf request should happen and executes it if so. I believe that this is the "correct" _(or more honestly, the more correct)_ way of performing auto golf swaps.

I'm hoping that this can address the NetPlay freezes. Fingers crossed